### PR TITLE
Use pkg-config to get libsmbclient CFLAGS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,26 @@ hello
 
 """
 
+import os
+import traceback
+import subprocess
 from distutils.core import setup, Extension
+
+
+def setup_libsmbclient():
+    try:
+        cflags = [subprocess.check_output([
+            "pkg-config", "--cflags", "smbclient"])]
+    except:
+        traceback.print_exc()
+    else:
+        os_cflags = os.getenv("CFLAGS")
+        if os_cflags:
+            cflags.append(os_cflags)
+        os.environ["CFLAGS"] = " ".join(cflags)
+
+setup_libsmbclient()
+
 setup (name="pysmbc",
        version="1.0.13",
        description="Python bindings for libsmbclient",


### PR DESCRIPTION
Hi,

This fix install of pysmbc on my debian testing where smbclient headers files are in /usr/include/samba-4.0

pkg-config (when availiable) can help fixing build on several OS setup/versions.

I also try to use Extension.extra_compile_args but distutils put my custom cflags at the end of the gcc command and it doesn't work...
