### PR TITLE
setup: Fix installation with python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def pkgconfig_I (pkg):
     c = subprocess.Popen (["pkg-config", "--cflags", pkg],
                           stdout=subprocess.PIPE)
     (stdout, stderr) = c.communicate ()
-    for p in stdout.decode (encoding='ascii').split ():
+    for p in stdout.decode ('ascii').split ():
         if p.startswith ("-I"):
             dirs.append (p[2:])
     return dirs


### PR DESCRIPTION
keyword arguments support in str.decode() was added in 2.7
