### PR TITLE
Fix hanging TCP connections, dealloc error

### DIFF
--- a/smbc/context.c
+++ b/smbc/context.c
@@ -381,12 +381,15 @@ Context_opendir (Context *self, PyObject *args)
     {
       smbc_DirType.tp_dealloc (dir);
       debugprintf ("%p <- Context_opendir() EXCEPTION\n", self->context);
-      return NULL;
+      dir = NULL;
     }
+	else
+	  {
+			debugprintf ("%p <- Context_opendir() = Dir\n", self->context);
+	  }
 
   Py_DECREF (largs);
   Py_DECREF (lkwlist);
-  debugprintf ("%p <- Context_opendir() = Dir\n", self->context);
   return dir;
 }
 


### PR DESCRIPTION
I encountered an issue when using the context to walk a remote windows machine.

On some folders, for example `smb://__foo__/C$/Users/__bar__/AppData/Local/Temporary Internet Files` I would get an `smbc.PermissionError`.

As long as the process lived, the internal TCP connection used by the smbclient stayed alive,
Although the context was long out of the scope (even tried **del** and **gcd.collect()**).

Digging in the code, seems the problem were dangling references that were not handled.

```c
static PyObject *
Context_opendir (Context *self, PyObject *args)
{
  PyObject *largs, *lkwlist;
  PyObject *uri;
  PyObject *dir;

  debugprintf ("%p -> Context_opendir()\n", self->context);
  if (!PyArg_ParseTuple (args, "O", &uri))
    {
      debugprintf ("%p <- Context_opendir() EXCEPTION\n", self->context);
      return NULL;
    }

  largs = Py_BuildValue ("()");
  lkwlist = PyDict_New ();
  PyDict_SetItemString (lkwlist, "context", (PyObject *) self);
  PyDict_SetItemString (lkwlist, "uri", uri);
  dir = smbc_DirType.tp_new (&smbc_DirType, largs, lkwlist);
  if (smbc_DirType.tp_init (dir, largs, lkwlist) < 0)
    {
       // -------------------------------------------------------------------------------
       // An Excpetion occured, but largs and lkwlist are still referenced
       // -------------------------------------------------------------------------------
      smbc_DirType.tp_dealloc (dir);
      debugprintf ("%p <- Context_opendir() EXCEPTION\n", self->context);
      return NULL;
    }

  // -------------------------------------------------------------------------------
  // Here are the references which are not DECREFed if an exception occurs
  // -------------------------------------------------------------------------------
  Py_DECREF (largs);
  Py_DECREF (lkwlist);
  debugprintf ("%p <- Context_opendir() = Dir\n", self->context);
  return dir;
}
```