### PR TITLE
Set client max protocol to SMB3 by default (instead of SMB1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def pkgconfig_I (pkg):
     return dirs
     
 setup (name="pysmbc",
-       version="1.0.15.5",
+       version="1.0.15.6",
        description="Python bindings for libsmbclient",
        long_description=__doc__,
        author=["Tim Waugh <twaugh@redhat.com>",

--- a/smbc/context.c
+++ b/smbc/context.c
@@ -381,12 +381,15 @@ Context_opendir (Context *self, PyObject *args)
     {
       smbc_DirType.tp_dealloc (dir);
       debugprintf ("%p <- Context_opendir() EXCEPTION\n", self->context);
-      return NULL;
+      dir = NULL;
     }
+	else
+	  {
+			debugprintf ("%p <- Context_opendir() = Dir\n", self->context);
+	  }
 
   Py_DECREF (largs);
   Py_DECREF (lkwlist);
-  debugprintf ("%p <- Context_opendir() = Dir\n", self->context);
   return dir;
 }
 


### PR DESCRIPTION
By default, the **client max version** configuration of libsmbclient uses SMB1.

We set the max version to hardcoded **SMB3** (similar to `-m SMB3` flag in `smbclient`).

New server do not longer support SMB1 (more because of wannacry).