### PR TITLE
Add the ability to set OptionFullTimeNames

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def pkgconfig_I (pkg):
     return dirs
     
 setup (name="pysmbc",
-       version="1.0.15.7",
+       version="1.0.15.8",
        description="Python bindings for libsmbclient",
        long_description=__doc__,
        author=["Tim Waugh <twaugh@redhat.com>",

--- a/smbc/context.c
+++ b/smbc/context.c
@@ -919,6 +919,28 @@ Context_setOptionDebugToStderr (Context *self, PyObject *value,
 }
 
 static PyObject *
+Context_getOptionFullTimeNames (Context *self, void *closure)
+{
+  smbc_bool b;
+  b = smbc_getOptionFullTimeNames (self->context);
+  return PyBool_FromLong ((long) b);
+}
+
+static int
+Context_setOptionFullTimeNames (Context *self, PyObject *value,
+				void *closure)
+{
+  if (!PyBool_Check (value))
+    {
+      PyErr_SetString (PyExc_TypeError, "must be Boolean");
+      return -1;
+    }
+
+  smbc_setOptionFullTimeNames (self->context, value == Py_True);
+  return 0;
+}
+
+static PyObject *
 Context_getOptionNoAutoAnonymousLogin (Context *self, void *closure)
 {
   smbc_bool b;
@@ -1020,6 +1042,12 @@ PyGetSetDef Context_getseters[] =
       (getter) Context_getOptionDebugToStderr,
       (setter) Context_setOptionDebugToStderr,
       "Whether to log to standard error instead of standard output.",
+      NULL },
+
+		{ "optionFullTimeNames",
+      (getter) Context_getOptionFullTimeNames,
+      (setter) Context_setOptionFullTimeNames,
+      "Use full time names (Create Time)",
       NULL },
 
     { "optionNoAutoAnonymousLogin",


### PR DESCRIPTION
This is needed when we want to access the `CREATE_TIME` xattribute.

```python
ctx.optionFullTimeNames = False
ctx.getxattr("smb://192.168.1.150/path/to/foo.doc", "system.dos_attr.*")
```

```
'MODE:0x20,SIZE:360630,A_TIME:1502201959,M_TIME:1502203577,C_TIME:1502203577,INODE:21955048183513888'
```

```python
ctx.optionFullTimeNames = True
ctx.getxattr("smb://192.168.1.150/path/to/foo.doc", "system.dos_attr.*")
```

```
'MODE:0x20,SIZE:360630,CREATE_TIME:1502201959,ACCESS_TIME:1502201959,WRITE_TIME:1502203577,CHANGE_TIME:1502203577,INODE:21955048183513888'
```