### PR TITLE
Setup: update distutils to setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+*.egg-info
 build
+dist
 smbc.so
 tests/*.pyc
 tests/settings.py

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 ## Authors:
 ##  Tim Waugh <twaugh@redhat.com>
 ##  Tsukasa Hamano <hamano@osstech.co.jp>
+##  Laurent Coustet <laurent.coustet@clarisys.fr>
 
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
@@ -50,43 +51,50 @@ hello
 
 """
 
-from distutils.core import setup, Extension
 import subprocess
+from setuptools import setup, Extension
 
-def pkgconfig_I (pkg):
+def pkgconfig_I(pkg):
     dirs = []
-    c = subprocess.Popen (["pkg-config", "--cflags", pkg],
-                          stdout=subprocess.PIPE)
+    c = subprocess.Popen(["pkg-config", "--cflags", pkg], stdout=subprocess.PIPE)
     (stdout, stderr) = c.communicate ()
-    for p in stdout.decode ('ascii').split ():
-        if p.startswith ("-I"):
-            dirs.append (p[2:])
+    for p in stdout.decode('ascii').split():
+        if p.startswith("-I"):
+            dirs.append(p[2:])
     return dirs
-    
-setup (name="pysmbc",
-       version="1.0.15.8",
-       description="Python bindings for libsmbclient",
-       long_description=__doc__,
-       author=["Tim Waugh <twaugh@redhat.com>",
-               "Tsukasa Hamano <hamano@osstech.co.jp>",
-               "Roberto Polli <rpolli@babel.it>" ],
-       url="http://cyberelk.net/tim/software/pysmbc/",
-       download_url="http://cyberelk.net/tim/data/pysmbc/",
-       classifiers=[
+
+setup(
+    name="pysmbc",
+    version="1.0.15.9",
+    description="Python bindings for libsmbclient",
+    long_description=__doc__,
+    author=[
+        "Tim Waugh <twaugh@redhat.com>",
+        "Tsukasa Hamano <hamano@osstech.co.jp>",
+        "Roberto Polli <rpolli@babel.it>",
+    ],
+    url="http://cyberelk.net/tim/software/pysmbc/",
+    download_url="http://cyberelk.net/tim/data/pysmbc/",
+    license="GPLv2+",
+    packages=["smbc"],
+    classifiers=[
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Development Status :: 5 - Production/Stable",
         "Operating System :: Unix",
         "Programming Language :: C",
+    ],
+    ext_modules=[
+        Extension("_smbc", [
+            "smbc/smbcmodule.c",
+            "smbc/context.c",
+            "smbc/dir.c",
+            "smbc/file.c",
+            "smbc/smbcdirent.c"
         ],
-       license="GPLv2+",
-       packages=["smbc"],
-       ext_modules=[Extension("_smbc",
-                              ["smbc/smbcmodule.c",
-                               "smbc/context.c",
-                               "smbc/dir.c",
-                               "smbc/file.c",
-                               "smbc/smbcdirent.c"],
-                              libraries=["smbclient"],
-                              include_dirs=pkgconfig_I("smbclient"))])
+        libraries=["smbclient"],
+        include_dirs=pkgconfig_I("smbclient")
+        )
+    ],
+)


### PR DESCRIPTION
The motivation for this move is to be able to generate wheels for pysmbc.

The wheels generation can be done in a way similar to what psycopg2 does.
The main repository still stay the same, but [https://github.com/zehome/pysmbc-wheels](pysmbc-wheels) will use travis-ci to generate wheels on manylinux1. (The wheel will include libsmbclient from the latest samba3, built on manylinux1 as well)

pysmbc-wheel is not ready yet, I'm currently actively working on it.