### PR TITLE
Update setup.py URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,7 @@ setup(
         "Tsukasa Hamano <hamano@osstech.co.jp>",
         "Roberto Polli <rpolli@babel.it>",
     ],
-    url="http://cyberelk.net/tim/software/pysmbc/",
-    download_url="http://cyberelk.net/tim/data/pysmbc/",
+    url="https://github.com/hamano/pysmbc",
     license="GPLv2+",
     packages=["smbc"],
     classifiers=[


### PR DESCRIPTION
Update the url parameter in setup.py to point to the GitHub page.

For those of us that arrive via PyPI, it's confusing to land at Tim's page:
http://cyberelk.net/tim/software/pysmbc/

This should make it easier for visitors to find this project, which I understand is the "correct" home.