### PR TITLE
Added SAMBA protocol version optional variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ def pkgconfig_L(pkg):
 
 setup(
     name="pysmbc",
-    version="1.0.18",
+    version="1.0.19",
     description="Python bindings for libsmbclient",
     long_description=__doc__,
     author=[

--- a/smbc/context.c
+++ b/smbc/context.c
@@ -116,15 +116,17 @@ Context_init (Context *self, PyObject *args, PyObject *kwds)
   PyObject *auth = NULL;
   int debug = 0;
   SMBCCTX *ctx;
+  char *proto = NULL;
   static char *kwlist[] =
     {
       "auth_fn",
       "debug",
+      "proto",
       NULL
     };
 
-  if (!PyArg_ParseTupleAndKeywords (args, kwds, "|Oi", kwlist,
-				    &auth, &debug))
+  if (!PyArg_ParseTupleAndKeywords (args, kwds, "|Oi|s", kwlist,
+				    &auth, &debug, &proto))
     {
       return -1;
     }
@@ -142,7 +144,13 @@ Context_init (Context *self, PyObject *args, PyObject *kwds)
     }
 
   debugprintf ("-> Setting  client max protocol to SMB3()\n");
-  lp_set_cmdline("client max protocol", "SMB3");
+  if(proto)
+  {
+    lp_set_cmdline("client max protocol", proto);
+    lp_set_cmdline("client min protocol", proto);
+  } else {
+    lp_set_cmdline("client max protocol", "SMB3");
+  }
 
   debugprintf ("-> Context_init ()\n");
 

--- a/smbc/context.c
+++ b/smbc/context.c
@@ -143,12 +143,15 @@ Context_init (Context *self, PyObject *args, PyObject *kwds)
       self->auth_fn = auth;
     }
 
-  debugprintf ("-> Setting  client max protocol to SMB3()\n");
+  debugprintf("-> wanted proto ver %s\n", proto);
   if(proto)
   {
+    debugprintf ("-> Setting  client max protocol to %s()\n", proto);
     lp_set_cmdline("client max protocol", proto);
+    debugprintf ("-> Setting  client min protocol to %s()\n", proto);
     lp_set_cmdline("client min protocol", proto);
   } else {
+    debugprintf ("-> Setting  client max protocol to SMB3()\n");
     lp_set_cmdline("client max protocol", "SMB3");
   }
 


### PR DESCRIPTION
Hello team,

I used pysmbc amount of time.
I was surprised at what there is no support for programmatical SMB protocol version selection.
Sometimes you can't rely on system's protocol version choice, because the old SMB version is blocked by server admins and etc.
Want to share with you my solution.

Also, you have registered issue on this topic: #29 