### PR TITLE
Makefile: Use $(PYTHON) for python command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
+PYTHON=python
 NAME=pysmbc
-VERSION:=$(shell python setup.py --version)
+VERSION:=$(shell $(PYTHON) setup.py --version)
 SDIST_ARGS=--formats=bztar -d.
 
 _smbc.so: force
-	python setup.py build
+	$(PYTHON) setup.py build
 	mv build/lib*/_smbc*.so .
 
 doc: _smbc.so
@@ -17,15 +18,15 @@ clean:
 	-rm -rf build smbc.so *.pyc tests/*.pyc *~ tests/*~ _smbc*.so 
 
 dist:
-	python setup.py sdist $(SDIST_ARGS)
+	$(PYTHON) setup.py sdist $(SDIST_ARGS)
 
 upload:
-	python setup.py sdist $(SDIST_ARGS) upload -s
+	$(PYTHON) setup.py sdist $(SDIST_ARGS) upload -s
 
 install:
 	ROOT= ; \
 	if [ -n "$$DESTDIR" ]; then ROOT="--root $$DESTDIR"; fi; \
-	python setup.py install $$ROOT
+	$(PYTHON) setup.py install $$ROOT
 
 .PHONY: doc doczip clean dist install force
 


### PR DESCRIPTION
I want to use `Makefile` for Python 3, but the static `python` command name is used in it. This patch defines `PYTHON=python` by default and use it to be able to override another Python command path, e.g., `make PYTHON=python3`.