### PR TITLE
Add File_seekable

### DIFF
--- a/smbc/file.c
+++ b/smbc/file.c
@@ -336,6 +336,12 @@ File_tell (File *self)
   return File_lseek (self, args);
 }
 
+static PyObject *
+File_seekable (File *self)
+{
+  return Py_BuildValue("b", 1);
+}
+
 PyMethodDef File_methods[] =
   {
 	{"read", (PyCFunction)File_read, METH_VARARGS,
@@ -379,6 +385,10 @@ PyMethodDef File_methods[] =
 	{"tell", (PyCFunction)File_tell, METH_NOARGS,
 	 "tell() -> int\n\n"
 	 "@return: on success, current location, othwerwise -1"
+	},
+	{"seekable", (PyCFunction)File_seekable, METH_NOARGS,
+	 "seekable() -> bool\n\n"
+	 "@return: determine if seekable"
 	},
     { NULL } /* Sentinel */
   };


### PR DESCRIPTION
Workaround for issue #53.

A small seek (+- 1 byte) could verify if the stream is really seekable.