### PR TITLE
smbc/context.c: Fix PY_MAJOR_VERSION define

### DIFF
--- a/smbc/context.c
+++ b/smbc/context.c
@@ -783,7 +783,7 @@ Context_setNetbiosName (Context *self, PyObject *value, void *closure)
       return -1;
     }
 
-#if PY_MAJOR_VERSION > 3
+#if PY_MAJOR_VERSION >= 3
   chars = PyUnicode_GET_LENGTH(value);
 #else
   chars = PyUnicode_GET_SIZE(value); /* not including NUL */
@@ -857,7 +857,7 @@ Context_setWorkgroup (Context *self, PyObject *value, void *closure)
       return -1;
     }
 
-#if PY_MAJOR_VERSION > 3
+#if PY_MAJOR_VERSION >= 3
   chars = PyUnicode_GET_LENGTH(value);
 #else
   chars = PyUnicode_GET_SIZE(value); /* not including NUL */


### PR DESCRIPTION
There is a [report](https://bugzilla.redhat.com/show_bug.cgi?id=2155419) in Fedora where Python team tried to build pysmbc with Python 3.12, which removes several already deprecated functions - in our case PyUnicode_GET_SIZE() is removed.

The problem was the PY_MAJOR_VERSION `define` wasn't including Python 3, so the Python 2 function was used. The PR fixes the problem.